### PR TITLE
Scoped packages cross-platform issue

### DIFF
--- a/src/node-modules.ts
+++ b/src/node-modules.ts
@@ -17,7 +17,8 @@ const getScopedPackages = ( path: string, file: string ): NodeModules => {
     if ( !json ) {
       return acc;
     }
-    acc[ join( file, scopedModulePath ) ] = {
+    const scopeModuleKey = `${file}/${scopedModulePath}`;
+    acc[ scopeModuleKey ] = {
       version: `${json.version || ''}`,
       resolved: `${json._resolved || ''}`
     };


### PR DESCRIPTION
path.join use different delimiter on different platforms. and scoped packages are always /-ish

Now on Windows:

```
----- uninstalled -----
@arkweid\lefthook : 0.6.3
@babel\code-frame : 7.0.0

----- installed -----
@arkweid/lefthook : 0.6.3
@babel/code-frame : 7.0.0
```